### PR TITLE
Corrección de sintaxis y estilo

### DIFF
--- a/Haskinator.hs
+++ b/Haskinator.hs
@@ -8,7 +8,7 @@
 import Data.Char
 import Data.Maybe
 import Control.Monad
-import Oraculo
+import Oráculo
 
 crearOráculo :: Maybe Oráculo
 crearOráculo = Nothing
@@ -68,19 +68,19 @@ calcularEspacio 0 = ""
 calcularEspacio 1 = "  "
 calcularEspacio n = "  " ++ calcularEspacio (n - 1)
 
-imprimirOraculo :: Oráculo -> Int -> String
-imprimirOraculo (Predecir xs) n =
-imprimirOraculo (Pregunta xs opos oneg) n
+imprimirOráculo :: Oráculo -> Int -> String
+imprimirOráculo (Predecir xs) n =
+imprimirOráculo (Pregunta xs opos oneg) n
   =  calcularEspacio n ++ "Pregunta: " ++ xs++ "\n"
-  ++ calcularEspacio n ++ "Oráculo positivo: " ++ imprimirOraculo opos (n + 1) ++ "\n"
-  ++ calcularEspacio n ++ "Oráculo negativo: " ++ imprimirOraculo oneg (n + 1)
+  ++ calcularEspacio n ++ "Oráculo positivo: " ++ imprimirOráculo opos (n + 1) ++ "\n"
+  ++ calcularEspacio n ++ "Oráculo negativo: " ++ imprimirOráculo oneg (n + 1)
 
 persistir :: Maybe Oráculo -> String
 persistir Nothing _  = putStrLn "Tratando de guardar un oráculo vacío"
 persistir (Just orc) name
   = do
     handle <- openFile name WriteMode
-    hPutStr handle $ imprimirOraculo orc 0
+    hPutStr handle $ imprimirOráculo orc 0
     -- FIXME: No estás cerrando el archivo!  Usa simplemente «writeFile» en vez de «openFile» y escritura por separado!
 
 obtenerPosición :: [(Bool, String)] -> [(Bool, String)] -> Int
@@ -99,8 +99,8 @@ consultarPreguntaCrucial preg1 preg2 maybeorc
         resp2 = obtenerCadena orc preg2
       in -- Te faltaba este «in».
         case (resp1, resp2) of
-          (Nothing, _      ) -> " Consulta inválida, la primera pregunta no existe"
-          (_      , Nothing) -> " Consulta inválida, la segunda pregunta no existe"
+          (Nothing, _      ) -> "Consulta inválida, la primera pregunta no existe"
+          (_      , Nothing) -> "Consulta inválida, la segunda pregunta no existe"
           (Just r1, Just r2) -> snd (r1 !! obtenerPosicion r1 r2)
 
 main = forever $ do
@@ -110,9 +110,9 @@ main = forever $ do
   putStrLn " 3. Persistir"
   putStrLn " 4. Cargar"
   putStrLn " 5. Consultar pregunta crucial"
-  putStrLn " 6. Consultar estadsticas"
-  op <-getLine 
-  let oraculoPrincipal = crearOraculo 
+  putStrLn " 6. Consultar estadísticas"
+  op <- getLine
+  let oráculoPrincipal = crearOráculo 
   case op of 
     "1" -> putStrLn "1"
     "2" -> putStrLn "2"
@@ -120,4 +120,4 @@ main = forever $ do
     "4" -> putStrLn "4"
     "5" -> putStrLn "5"
     "6" -> putStrLn "6"
-    other -> putStrLn "No es una opcion valida."
+    other -> putStrLn "No es una opción válida."

--- a/Haskinator.hs
+++ b/Haskinator.hs
@@ -1,102 +1,116 @@
 -- Archivo: Haskinator.hs
--- Este archivo contiene el main del programa, el menu de opciones, y las funcionalidades basicas
+-- Este archivo contiene el main del programa, el menú de opciones, y las funcionalidades básicas
 -- de Haskinator.
--- Autores: 
+-- Autores:
 --    - Francisco Martinez 09-10502
 --    - Gabriel Alvarez    09-10029
 
 import Data.Char
 import Data.Maybe
 import Control.Monad
-import Oraculo     
+import Oraculo
 
+crearOráculo :: Maybe Oráculo
+crearOráculo = Nothing
 
+obtenerNodo :: Oráculo -> [(Bool, String)] -> Oráculo
+obtenerNodo orc [] = orc
+obtenerNodo (Pregunta str opos oneg ) ((x, _):xs)
+  = obtenerNodo (if x then opos else oneg) xs
 
-crearOraculo :: Maybe Oraculo 
-crearOraculo = Nothing        
+predecir :: Maybe Oráculo -> Maybe Oráculo
+predecir maybeOráculo
+  = case maybeOráculo of 
+    Nothing -> do
+      putStrLn "Oráculo vacio"
+      putStrLn "Inserte su nueva pregunta"
+      nuevaPreg <- getLine
+      putStrLn "Respuesta correcta para la pregunta:"
+      nuevaPredPos <- getLine
+      putStrLn "Respuesta incorrecta para la pregunta:"
+      nuevaPredNeg <- getLine 
+      crearPregunta
+        nuevaPreg
+        (crearPredicción nuevaPredPos)
+        (crearPredicción nuevaPredNEg) 
+      putStrLn "Información agregada." 
 
-obtenerNodo :: Oraculo -> [(Bool,String)] -> Oraculo
-obtenerNodo orc [] = orc 
-obtenerNodo (Pregunta str opos oneg ) (x:xs) = if fst ( x ) == True   
-                                               then obtenerNodo opos xs    
-                                               else obtenerNodo oneg xs      
-predecir :: Maybe Oraculo -> Maybe Oraculo 
-predecir maybeOraculo = case maybeOraculo of 
-                             Nothing  -> do putStrLn "Oraculo vacio"
-                                            putStrLn "Inserte su nueva pregunta "
-                                            nuevaPreg <- getLine
-                                            putStrLn "Respuesta correcta para la pregunta :"
-                                            nuevaPredPos <- getLine
-                                            putStrLn "Respuesta incorrecta para la pregunta :"
-                                            nuevaPredNeg <- getLine 
-                                            crearPregunta nuevaPreg (crearPrediccion nuevaPredPos) (crearPrediccion nuevaPredNEg) 
-                                            putStrLn "Informacion agregada." 
-                                            
-                             Just orc -> do predecir' orc 
-                               where      
-                                 predecir' ( Pregunta preg opos oneg ) = do putStr preg ++ " "  
-                                                                            putStrLn "(Si/No)" 
-                                                                            resp <- getLine
-                                                                            case resp of 
-                                                                              "Si" -> predecir (Just opos)
-                                                                              "No" -> predecir (Just oneg)
-                                 predecir' ( Prediccion pred )         = do putStr pred
-                                                                            putStrLn "( Acertada | Incorrecta )"
-                                                                            resp <- getLine
-                                                                            case resp of 
-                                                                              "Acertada"   -> Nothing
-                                                                              "Incorrecta" -> do -- putStrLn "Respuesta correcta : "
-                                                                                                 -- nuevaPred <- getLine
-                                                                                                 -- crearPrediccion nuevaPred 
-                                                                                                 -- putStr "Agrega una nueva pregunta por   favor"
-                                                                                                 -- putStr "(Que sea  verdadera   para   la nueva" 
-                                                                                                 -- putStrLn "prediccion  y falsa para la anterior)"
-                                                                                                 -- nuevaPreg <- getLine 
-                                                                                                 -- crearPregunta nuevaPreg nuevaPred (Prediccion pred) 
-                                                                                                 -- let padre = obtenerNodo orc (obtenerCadena orc pred 
-                                                                                                 putStrLn " Aqui aun no se termina "  
-                                                                                                 
-                                                                              
+    Just orc ->
+      predecir' orc
+
+  where
+    predecir' (Pregunta preg opos oneg)
+      = do
+        putStrLn $ preg ++ " (Sí/No)" 
+        resp <- getLine
+        case resp of 
+          "Sí" -> predecir (Just opos)
+          "No" -> predecir (Just oneg)
+
+    predecir' (Predicción pred)
+      = do
+        putStrLn $ pred ++ " (Acertada | Incorrecta)"
+        resp <- getLine
+        case resp of
+          "Acertada" -> Nothing
+          "Incorrecta" -> do
+            -- putStrLn "Respuesta correcta:"
+            -- nuevaPred <- getLine
+            -- crearPrediccion nuevaPred
+            -- putStr "Agrega una nueva pregunta por favor (que sea verdadera para la nueva predicciony falsa para la anterior)"
+            -- nuevaPreg <- getLine 
+            -- crearPregunta nuevaPreg nuevaPred (Predicción pred) 
+            -- let padre = obtenerNodo orc (obtenerCadena orc pred 
+            putStrLn "Aquí aún no se termina"
+
 calcularEspacio :: Int -> String                                                                               
-calcularEspacio 0 = ""  
-calcularEspacio 1 = "  " 
-calcularEspacio n = "  " ++ calcularEspacio (n-1) 
+calcularEspacio 0 = ""
+calcularEspacio 1 = "  "
+calcularEspacio n = "  " ++ calcularEspacio (n - 1)
 
-imprimirOraculo :: Oraculo -> Int -> String
-imprimirOraculo ( Predecir xs ) n  =  
-imprimirOraculo ( Pregunta xs opos oneg ) n =  (calcularEspacio n ) ++ "Pregunta: "++ xs ++ "\n" ++  (calcularEspacio n ) ++ "Oraculo positivo: " ++ (imprimirOraculo opos n+1)  ++ "\n" ++  (calcularEspacio n ) ++ "Oraculo negativo: " ++ (imprimirOraculo oneg n+1)  
+imprimirOraculo :: Oráculo -> Int -> String
+imprimirOraculo (Predecir xs) n =
+imprimirOraculo (Pregunta xs opos oneg) n
+  =  calcularEspacio n ++ "Pregunta: " ++ xs++ "\n"
+  ++ calcularEspacio n ++ "Oráculo positivo: " ++ imprimirOraculo opos (n + 1) ++ "\n"
+  ++ calcularEspacio n ++ "Oráculo negativo: " ++ imprimirOraculo oneg (n + 1)
 
-persistir :: Maybe Oraculo -> String                             
-persistir Nothing _  = putStrLn " Tratando de guardar un Oraculo vacio " 
-persistir ( Just orc ) name = do handle <- openFile name WriteMode 
-                                 hPutStr handle ( imprimirOraculo orc 0 )
-                                 
-                                 
+persistir :: Maybe Oráculo -> String
+persistir Nothing _  = putStrLn "Tratando de guardar un oráculo vacío"
+persistir (Just orc) name
+  = do
+    handle <- openFile name WriteMode
+    hPutStr handle $ imprimirOraculo orc 0
+    -- FIXME: No estás cerrando el archivo!  Usa simplemente «writeFile» en vez de «openFile» y escritura por separado!
 
-obtenerPosicion :: [(Bool,String)] -> [(Bool,String)] -> Int   
-obtenerPosicion (x:xs) (y:ys) =  if ( snd x == snd y ) 
-                                     then 1 + obtenerPosicion xs ys 
-                                     else 0       
+obtenerPosición :: [(Bool, String)] -> [(Bool, String)] -> Int
+obtenerPosición ((_, x):xs) ((_, y):ys)
+  = if x == y
+    then 1 + obtenerPosición xs ys
+    else 0
 
-consultarPreguntaCrucial:: String -> String -> Maybe Oraculo -> String                                 
-consultarPreguntaCrucial preg1 preg2 maybeorc = case maybeorc of  Nothing -> putStrLn "Oraculo vacio"
-                                                                  Just orc-> let resp1 = obtenerCadena orc preg1    
-                                                                                 resp2 = obtenerCadena orc preg2 
-                                                                                 case (resp1,resp2) of (Nothing ,   _   )     -> " Consulta invalida, la primera pregunta no existe "  
-                                                                                                       (   _    ,Nothing)     -> " Consulta invalida, la segunda pregunta no existe " 
-                                                                                                       ((Just r1),(Just r2))  -> snd (r1 !! (obtenerPosicion r1 r2))     
+consultarPreguntaCrucial :: String -> String -> Maybe Oráculo -> String
+consultarPreguntaCrucial preg1 preg2 maybeorc
+  = case maybeorc of
+    Nothing -> putStrLn "Oráculo vacio"
+    Just orc ->
+      let
+        resp1 = obtenerCadena orc preg1
+        resp2 = obtenerCadena orc preg2
+      in -- Te faltaba este «in».
+        case (resp1, resp2) of
+          (Nothing, _      ) -> " Consulta inválida, la primera pregunta no existe"
+          (_      , Nothing) -> " Consulta inválida, la segunda pregunta no existe"
+          (Just r1, Just r2) -> snd (r1 !! obtenerPosicion r1 r2)
 
-                                               
-                                               
-                                                                                                               
-main = forever $ do  
-  putStrLn " Elige alguna opcion: " 
-  putStrLn " 1. Crear un oraculo nuevo " 
-  putStrLn " 2. Predecir "
-  putStrLn " 3. Persistir "
-  putStrLn " 4. Cargar " 
-  putStrLn " 5. Consultar pregunta crucial " 
-  putStrLn " 6. Consultar estadisticas "
+main = forever $ do
+  putStrLn " Elige alguna opción:"
+  putStrLn " 1. Crear un oráculo nuevo"
+  putStrLn " 2. Predecir"
+  putStrLn " 3. Persistir"
+  putStrLn " 4. Cargar"
+  putStrLn " 5. Consultar pregunta crucial"
+  putStrLn " 6. Consultar estadsticas"
   op <-getLine 
   let oraculoPrincipal = crearOraculo 
   case op of 


### PR DESCRIPTION
El error de sintaxis era por un `in` faltante en un `let`.

Intenta seguir un estilo similar al de esta versión del código.  Cuida la ortografía, no uses _tabs_ nunca, evita espacios sobrantes en general, y haz lo posible para que la indentación crezca siempre de a dos espacios por incremento, no más.  No hagas alineación a elementos sintácticos particulares sino por incrementos fijos de profundidad de indentación, que así ahorras mucho espacio y el código es mucho más legible, y evitas posibles errores de sintaxis por la regla de _layout_ de _Haskell_.
